### PR TITLE
Fix subfolder handling.

### DIFF
--- a/maildirdiff.py
+++ b/maildirdiff.py
@@ -160,8 +160,12 @@ def index(messages, mbox, root):
             pass
 
     for folder in mbox.list_folders():
-        print("Folder found: %s" % folder)
-        index(messages, folder, root)
+        folder_mbox = mbox.get_folder(folder)
+        if is_maildir(folder_mbox._path):
+            print("Folder found: %s" % folder)
+            index(messages, folder_mbox, root)
+        elif verbose:
+            print("Folder is not a valid Maildir: %s" % folder, file=sys.stderr)
 
 
 def get_mailbox_dir(location):

--- a/maildirdiff.py
+++ b/maildirdiff.py
@@ -160,7 +160,7 @@ def index(messages, mbox, root):
             pass
 
     for subdir in mbox.list_folders():
-        print("Subdir found: %s", subdir)
+        print("Subdir found: %s" % subdir)
         index(messages, subdir, root)
 
 

--- a/maildirdiff.py
+++ b/maildirdiff.py
@@ -159,9 +159,9 @@ def index(messages, mbox, root):
         except TypeError:
             pass
 
-    for subdir in mbox.list_folders():
-        print("Subdir found: %s" % subdir)
-        index(messages, subdir, root)
+    for folder in mbox.list_folders():
+        print("Folder found: %s" % folder)
+        index(messages, folder, root)
 
 
 def get_mailbox_dir(location):


### PR DESCRIPTION
Closes #2 and #3.

With this changes in this branch, maildirdiff runs without errors on my 3.6G (without the Spam folders, that I left aside :wink:) Maildir.